### PR TITLE
Update incorrect function call in ddp train.py

### DIFF
--- a/templates/src/mlp/ddp/train.py
+++ b/templates/src/mlp/ddp/train.py
@@ -212,7 +212,7 @@ class DDPMLPTrainer(submitit.helpers.Checkpointable):
             torch.cuda.manual_seed(seed)
 
         # Setup distributed training
-        self._initialize_distributed(rank, world_size)
+        self._setup_distributed(rank, world_size)
 
         # Setup device and model
         device, model = self._initialize_device_and_model(cfg, local_rank)


### PR DESCRIPTION
I was just reading through the code and found in line 215 there's a call to `_initialize_distributed` function but it's not defined anywhere. IIUC this is meant to call `_setup_distributed` (it's defined but not used anywhere)? If not, feel free to update or close this PR:) 
